### PR TITLE
Add support for Marks of the Embrujo

### DIFF
--- a/BlasII.CheatConsole/CheatConsole.cs
+++ b/BlasII.CheatConsole/CheatConsole.cs
@@ -236,6 +236,7 @@ public class CheatConsole : BlasIIMod
         provider.RegisterCommand(new RangeStatCommand("flask", "Flask"));
         provider.RegisterCommand(new ValueStatCommand("tears", "Tears"));
         provider.RegisterCommand(new ValueStatCommand("marks", "Orbs"));
+        provider.RegisterCommand(new ValueStatCommand("emarks", "DLC2Coins"));
         provider.RegisterCommand(new ValueStatCommand("pmarks", "MarksPreceptor"));
         provider.RegisterCommand(new ModifyStatCommand("attack", "BasePhysicalattack"));
         provider.RegisterCommand(new ModifyStatCommand("defense", "GlobalDefense"));

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -108,6 +108,13 @@
 
 ---
 
+### Marks of the Embrujo
+```emarks add {amount}``` - Adds the specified amount of marks
+
+```emarks current``` - Displays the current amount of marks
+
+---
+
 ### Marks of the Preceptor
 ```pmarks add {amount}``` - Adds the specified amount of marks
 


### PR DESCRIPTION
This adds the `emarks` command which can be used to get the current number of Marks of the Embrujo as well as adding new ones.